### PR TITLE
Add logo to images, add tests, update verifiers

### DIFF
--- a/TMDbLib/Objects/General/Images.cs
+++ b/TMDbLib/Objects/General/Images.cs
@@ -10,5 +10,8 @@ namespace TMDbLib.Objects.General
 
         [JsonProperty("posters")]
         public List<ImageData> Posters { get; set; }
+
+        [JsonProperty("logos")]
+        public List<ImageData> Logos { get; set; }
     }
 }

--- a/TMDbLibTests/ClientMovieTests.cs
+++ b/TMDbLibTests/ClientMovieTests.cs
@@ -154,11 +154,13 @@ namespace TMDbLibTests
 
             ImageData backdrop = resp.Backdrops.Single(s => s.FilePath == "/js3J4SBiRfLvmRzaHoTA2tpKROw.jpg");
             ImageData poster = resp.Posters.Single(s => s.FilePath == "/c4G6lW5hAWmwveThfLSqs52yHB1.jpg");
+            ImageData logo = resp.Logos.Single(s => s.FilePath == "/sZcHIwp0UD7aqOKzPkOqtd63F9r.png");
 
             await Verify(new
             {
                 backdrop,
-                poster
+                poster,
+                logo
             });
         }
 
@@ -171,11 +173,13 @@ namespace TMDbLibTests
 
             ImageData backdrop = images.Backdrops.Single(s => s.FilePath == "/js3J4SBiRfLvmRzaHoTA2tpKROw.jpg");
             ImageData poster = images.Posters.Single(s => s.FilePath == "/9Zq88w35f1PpM22TIbf2amtjHD6.jpg");
+            ImageData logo = images.Logos.Single(s => s.FilePath == "/sZcHIwp0UD7aqOKzPkOqtd63F9r.png");
 
             await Verify(new
             {
                 backdrop,
-                poster
+                poster,
+                logo
             });
         }
 
@@ -189,11 +193,13 @@ namespace TMDbLibTests
 
             ImageData backdrop = images.Backdrops.Single(s => s.FilePath == "/4U9fN2jsQ94GQfDGeLEe8UaReRO.jpg");
             ImageData poster = images.Posters.Single(s => s.FilePath == "/8VV4YUwOGxgolFZTo2SgNwsfznR.jpg");
+            ImageData logo = images.Logos.Single(s => s.FilePath == "/jIWzq9B4KPH9hyUISlma02ijTFb.png");
 
             await Verify(new
             {
                 backdrop,
-                poster
+                poster,
+                logo
             });
         }
 

--- a/TMDbLibTests/ClientTvShowTests.cs
+++ b/TMDbLibTests/ClientTvShowTests.cs
@@ -153,11 +153,13 @@ namespace TMDbLibTests
 
             ImageData backdrop = images.Backdrops.Single(s => s.FilePath == "/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg");
             ImageData poster = images.Posters.Single(s => s.FilePath == "/ggFHVNu6YYI5L9pCfOacjizRGt.jpg");
+            ImageData logo = images.Logos.Single(s => s.FilePath == "/chw44B2VnLha8iiTdyZcIW0ZELC.png");
 
             await Verify(new
             {
                 backdrop,
-                poster
+                poster,
+                logo
             });
         }
 
@@ -170,11 +172,13 @@ namespace TMDbLibTests
 
             ImageData backdrop = images.Backdrops.Single(s => s.FilePath == "/otCnAN1edreRudT5E2OHk8beiDu.jpg");
             ImageData poster = images.Posters.Single(s => s.FilePath == "/ggFHVNu6YYI5L9pCfOacjizRGt.jpg");
+            ImageData logo = images.Logos.Single(s => s.FilePath == "/bM2bNffZlZ2UxZqwHaxr5VS3UUI.svg");
 
             await Verify(new
             {
                 backdrop,
-                poster
+                poster,
+                logo
             });
         }
 
@@ -195,11 +199,13 @@ namespace TMDbLibTests
 
             ImageData backdrop = null;
             ImageData poster = resp.Images.Posters.Single(s => s.FilePath == "/30erzlzIOtOK3k3T3BAl1GiVMP1.jpg");
+            ImageData logo = null;
 
             await Verify(new
             {
                 backdrop,
-                poster
+                poster,
+                logo
             });
         }
 

--- a/TMDbLibTests/Helpers/TestImagesHelpers.cs
+++ b/TMDbLibTests/Helpers/TestImagesHelpers.cs
@@ -8,12 +8,13 @@ namespace TMDbLibTests.Helpers
 {
     public static class TestImagesHelpers
     {
-        private static readonly Regex ImagePathRegex = new Regex(@"^/[a-zA-Z0-9]{26,}\.(?:jpg|png)$", RegexOptions.Compiled);
+        private static readonly Regex ImagePathRegex = new Regex(@"^/[a-zA-Z0-9]{26,}\.(?:jpg|png|svg)$", RegexOptions.Compiled);
 
         public static void TestImagePaths(Images images)
         {
             TestImagePaths(images.Backdrops);
             TestImagePaths(images.Posters);
+            TestImagePaths(images.Logos);
         }
 
         public static void TestImagePaths(IEnumerable<string> imagePaths)

--- a/TMDbLibTests/Verification/ClientMovieTests.TestMoviesGetMovieImages.verified.txt
+++ b/TMDbLibTests/Verification/ClientMovieTests.TestMoviesGetMovieImages.verified.txt
@@ -1,16 +1,23 @@
 {
   backdrop: {
-    aspect_ratio: 1.777777777777778,
+    aspect_ratio: 1.778,
     file_path: <non-empty>,
     height: 720,
     iso_639_1: en,
     width: 1280
   },
   poster: {
-    aspect_ratio: 0.6666666666666666,
+    aspect_ratio: 0.667,
     file_path: <non-empty>,
     height: 2100,
     iso_639_1: it,
     width: 1400
+  },
+  logo: {
+    aspect_ratio: 2.732,
+    file_path: <non-empty>,
+    height: 467,
+    iso_639_1: en,
+    width: 1276
   }
 }

--- a/TMDbLibTests/Verification/ClientMovieTests.TestMoviesGetMovieImagesWithImageLanguage.verified.txt
+++ b/TMDbLibTests/Verification/ClientMovieTests.TestMoviesGetMovieImagesWithImageLanguage.verified.txt
@@ -1,16 +1,23 @@
 {
   backdrop: {
-    aspect_ratio: 1.777777777777778,
+    aspect_ratio: 1.778,
     file_path: <non-empty>,
     height: 720,
     iso_639_1: en,
     width: 1280
   },
   poster: {
-    aspect_ratio: 0.6666666666666666,
+    aspect_ratio: 0.667,
     file_path: <non-empty>,
     height: 2100,
     iso_639_1: en,
     width: 1400
+  },
+  logo: {
+    aspect_ratio: 2.732,
+    file_path: <non-empty>,
+    height: 467,
+    iso_639_1: en,
+    width: 1276
   }
 }

--- a/TMDbLibTests/Verification/ClientMovieTests.TestMoviesGetMovieWithImageLanguage.verified.txt
+++ b/TMDbLibTests/Verification/ClientMovieTests.TestMoviesGetMovieWithImageLanguage.verified.txt
@@ -1,16 +1,23 @@
 {
   backdrop: {
-    aspect_ratio: 1.777777777777778,
+    aspect_ratio: 1.778,
     file_path: <non-empty>,
     height: 1080,
     iso_639_1: de,
     width: 1920
   },
   poster: {
-    aspect_ratio: 0.6666666666666666,
+    aspect_ratio: 0.667,
     file_path: <non-empty>,
     height: 1500,
     iso_639_1: de,
     width: 1000
+  },
+  logo: {
+    aspect_ratio: 3.841,
+    file_path: <non-empty>,
+    height: 207,
+    iso_639_1: de,
+    width: 795
   }
 }

--- a/TMDbLibTests/Verification/ClientTvShowTests.TestTvShowGetImagesWithImageLanguageAsync.verified.txt
+++ b/TMDbLibTests/Verification/ClientTvShowTests.TestTvShowGetImagesWithImageLanguageAsync.verified.txt
@@ -1,16 +1,23 @@
 {
   backdrop: {
-    aspect_ratio: 1.777777777777778,
+    aspect_ratio: 1.778,
     file_path: <non-empty>,
     height: 1080,
     iso_639_1: en,
     width: 1920
   },
   poster: {
-    aspect_ratio: 0.6666666666666666,
+    aspect_ratio: 0.667,
     file_path: <non-empty>,
     height: 1800,
     iso_639_1: en,
     width: 1200
+  },
+  logo: {
+    aspect_ratio: 1.68,
+    file_path: <non-empty>,
+    height: 219,
+    iso_639_1: en,
+    width: 368
   }
 }

--- a/TMDbLibTests/Verification/ClientTvShowTests.TestTvShowSeparateExtrasImagesAsync.verified.txt
+++ b/TMDbLibTests/Verification/ClientTvShowTests.TestTvShowSeparateExtrasImagesAsync.verified.txt
@@ -1,15 +1,22 @@
 {
   backdrop: {
-    aspect_ratio: 1.777251184834123,
+    aspect_ratio: 1.777,
     file_path: <non-empty>,
     height: 1688,
     width: 3000
   },
   poster: {
-    aspect_ratio: 0.6666666666666666,
+    aspect_ratio: 0.667,
     file_path: <non-empty>,
     height: 1800,
     iso_639_1: en,
     width: 1200
+  },
+  logo: {
+    aspect_ratio: 1.68,
+    file_path: <non-empty>,
+    height: 1300,
+    iso_639_1: en,
+    width: 2184
   }
 }

--- a/TestApplication/Program.cs
+++ b/TestApplication/Program.cs
@@ -82,13 +82,17 @@ namespace TestApplication
 
             Console.WriteLine("Fetching images for '" + movie.Title + "'");
 
-            // Images come in two forms, each dispayed below
+            // Images come in three forms, each dispayed below
             Console.WriteLine("Displaying Backdrops");
             await ProcessImages(client, movie.Images.Backdrops.Take(3), client.Config.Images.BackdropSizes);
             Console.WriteLine();
 
             Console.WriteLine("Displaying Posters");
             await ProcessImages(client, movie.Images.Posters.Take(3), client.Config.Images.PosterSizes);
+            Console.WriteLine();
+
+            Console.WriteLine("Displaying Logos");
+            await ProcessImages(client, movie.Images.Logos.Take(3), client.Config.Images.LogoSizes);
             Console.WriteLine();
 
             Spacer();


### PR DESCRIPTION
Logo images are available through the `getImages` queries, though it's not documented in the API docs.

See here: https://www.themoviedb.org/talk/5b8effd792514173b2000bb9?language=en-US&page=2

Logo sizes are already available in the `APIConfigurationImages` object.

