### PR TITLE
Fix for issue #414

### DIFF
--- a/TMDbLib/Objects/General/MediaType.cs
+++ b/TMDbLib/Objects/General/MediaType.cs
@@ -18,7 +18,7 @@ namespace TMDbLib.Objects.General
         [EnumValue("person")]
         Person = 3,
 
-        [EnumValue("episode")]
+        [EnumValue("tv_episode")]
         Episode = 4
     }
 }


### PR DESCRIPTION
Actually media_type parser for Episodes value is episode. But it seems TMDB changes that value to tv_episode.