### PR TITLE
All trending and localized trending methods

### DIFF
--- a/TMDbLib/Client/TMDbClientTrending.cs
+++ b/TMDbLib/Client/TMDbClientTrending.cs
@@ -54,5 +54,20 @@ namespace TMDbLib.Client
 
             return resp;
         }
+
+        public async Task<SearchContainer<SearchBase>> GetTrendingAllAsync(TimeWindow timeWindow, int page = 0, string language = null, CancellationToken cancellationToken = default)
+        {
+            RestRequest req = _client.Create("trending/all/{time_window}");
+            req.AddUrlSegment("time_window", timeWindow.GetDescription());
+
+            if (page >= 1)
+                req.AddQueryString("page", page.ToString());
+            if (language != null)
+                req.AddQueryString("language", language);
+
+            SearchContainer<SearchBase> resp = await req.GetOfT<SearchContainer<SearchBase>>(cancellationToken).ConfigureAwait(false);
+
+            return resp;
+        }
     }
 }

--- a/TMDbLib/Client/TMDbClientTrending.cs
+++ b/TMDbLib/Client/TMDbClientTrending.cs
@@ -10,39 +10,45 @@ namespace TMDbLib.Client
 {
     public partial class TMDbClient
     {
-        public async Task<SearchContainer<SearchMovie>> GetTrendingMoviesAsync(TimeWindow timeWindow, int page = 0, CancellationToken cancellationToken = default)
+        public async Task<SearchContainer<SearchMovie>> GetTrendingMoviesAsync(TimeWindow timeWindow, int page = 0, string language = null, CancellationToken cancellationToken = default)
         {
             RestRequest req = _client.Create("trending/movie/{time_window}");
             req.AddUrlSegment("time_window", timeWindow.GetDescription());
 
             if (page >= 1)
                 req.AddQueryString("page", page.ToString());
+            if (language != null)
+                req.AddQueryString("language", language);
 
             SearchContainer<SearchMovie> resp = await req.GetOfT<SearchContainer<SearchMovie>>(cancellationToken).ConfigureAwait(false);
 
             return resp;
         }
 
-        public async Task<SearchContainer<SearchTv>> GetTrendingTvAsync(TimeWindow timeWindow, int page = 0, CancellationToken cancellationToken = default)
+        public async Task<SearchContainer<SearchTv>> GetTrendingTvAsync(TimeWindow timeWindow, int page = 0, string language = null, CancellationToken cancellationToken = default)
         {
             RestRequest req = _client.Create("trending/tv/{time_window}");
             req.AddUrlSegment("time_window", timeWindow.GetDescription());
 
             if (page >= 1)
                 req.AddQueryString("page", page.ToString());
+            if (language != null)
+                req.AddQueryString("language", language);
 
             SearchContainer<SearchTv> resp = await req.GetOfT<SearchContainer<SearchTv>>(cancellationToken).ConfigureAwait(false);
 
             return resp;
         }
 
-        public async Task<SearchContainer<SearchPerson>> GetTrendingPeopleAsync(TimeWindow timeWindow, int page = 0, CancellationToken cancellationToken = default)
+        public async Task<SearchContainer<SearchPerson>> GetTrendingPeopleAsync(TimeWindow timeWindow, int page = 0, string language = null, CancellationToken cancellationToken = default)
         {
             RestRequest req = _client.Create("trending/person/{time_window}");
             req.AddUrlSegment("time_window", timeWindow.GetDescription());
 
             if (page >= 1)
                 req.AddQueryString("page", page.ToString());
+            if (language != null)
+                req.AddQueryString("language", language);
 
             SearchContainer<SearchPerson> resp = await req.GetOfT<SearchContainer<SearchPerson>>(cancellationToken).ConfigureAwait(false);
 

--- a/TMDbLibTests/ClientTrendingTests.cs
+++ b/TMDbLibTests/ClientTrendingTests.cs
@@ -29,5 +29,12 @@ namespace TMDbLibTests
             SearchContainer<SearchPerson> people = await TMDbClient.GetTrendingPeopleAsync(TimeWindow.Week);
             Assert.NotEmpty(people.Results);
         }
+
+        [Fact]
+        public async Task TestTrendingAllAsync()
+        {
+            SearchContainer<SearchBase> all = await TMDbClient.GetTrendingAllAsync(TimeWindow.Week);
+            Assert.NotEmpty(all.Results);
+        }
     }
 }


### PR DESCRIPTION
Added get all trending method: https://developers.themoviedb.org/3/trending/get-trending

The API documentation does not mention it, but trending methods accept a `language` query parameter.

For example:
https://api.themoviedb.org/3/trending/movie/week?api_key=api_key&language=de-DE
https://api.themoviedb.org/3/trending/tv/week?api_key=api_key&language=de-DE
https://api.themoviedb.org/3/trending/person/week?api_key=api_key&language=de-DE
https://api.themoviedb.org/3/trending/all/week?api_key=api_key&language=de-DE