### PR TITLE
Extend MediaType

### DIFF
--- a/TMDbLib/Objects/General/MediaType.cs
+++ b/TMDbLib/Objects/General/MediaType.cs
@@ -19,6 +19,15 @@ namespace TMDbLib.Objects.General
         Person = 3,
 
         [EnumValue("episode")]
-        Episode = 4
+        Episode = 4,
+
+        [EnumValue("tv_episode")]
+        TvEpisode = 5,
+
+        [EnumValue("season")]
+        Season = 6,
+
+        [EnumValue("tv_season")]
+        TvSeason = 7
     }
 }

--- a/TMDbLib/Objects/Search/SearchTvSeason.cs
+++ b/TMDbLib/Objects/Search/SearchTvSeason.cs
@@ -1,18 +1,21 @@
 ﻿using System;
 using Newtonsoft.Json;
+using TMDbLib.Objects.General;
 
 namespace TMDbLib.Objects.Search
 {
-    public class SearchTvSeason
+    public class SearchTvSeason : SearchBase
     {
+        public SearchTvSeason()
+        {
+            MediaType = MediaType.Season;
+        }
+
         [JsonProperty("air_date")]
         public DateTime? AirDate { get; set; }
 
         [JsonProperty("episode_count")]
         public int EpisodeCount { get; set; }
-
-        [JsonProperty("id")]
-        public int Id { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/TMDbLib/Utilities/Converters/SearchBaseConverter.cs
+++ b/TMDbLib/Utilities/Converters/SearchBaseConverter.cs
@@ -28,23 +28,17 @@ namespace TMDbLib.Utilities.Converters
                 // Determine the type based on the media_type
                 MediaType mediaType = jObject["media_type"].ToObject<MediaType>();
 
-                switch (mediaType)
+                result = mediaType switch
                 {
-                    case MediaType.Movie:
-                        result = new SearchMovie();
-                        break;
-                    case MediaType.Tv:
-                        result = new SearchTv();
-                        break;
-                    case MediaType.Person:
-                        result = new SearchPerson();
-                        break;
-                    case MediaType.Episode:
-                        result = new SearchTvEpisode();
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+                    MediaType.Movie => new SearchMovie(),
+                    MediaType.Tv => new SearchTv(),
+                    MediaType.Person => new SearchPerson(),
+                    MediaType.Episode => new SearchTvEpisode(),
+                    MediaType.TvEpisode => new SearchTvEpisode(),
+                    MediaType.Season => new SearchTvSeason(),
+                    MediaType.TvSeason => new SearchTvSeason(),
+                    _ => throw new ArgumentOutOfRangeException(),
+                };
             }
 
             // Populate the result

--- a/TMDbLib/Utilities/Converters/TaggedImageConverter.cs
+++ b/TMDbLib/Utilities/Converters/TaggedImageConverter.cs
@@ -24,21 +24,14 @@ namespace TMDbLib.Utilities.Converters
                 serializer.Populate(jsonReader, result);
 
             JToken mediaJson = jObject["media"];
-            switch (result.MediaType)
+            result.Media = result.MediaType switch
             {
-                case MediaType.Movie:
-                    result.Media = mediaJson.ToObject<SearchMovie>();
-                    break;
-                case MediaType.Tv:
-                    result.Media = mediaJson.ToObject<SearchTv>();
-                    break;
-                case MediaType.Episode:
-                    result.Media = mediaJson.ToObject<SearchTvEpisode>();
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-
+                MediaType.Movie => mediaJson.ToObject<SearchMovie>(),
+                MediaType.Tv => mediaJson.ToObject<SearchTv>(),
+                MediaType.Episode => mediaJson.ToObject<SearchTvEpisode>(),
+                MediaType.Season => mediaJson.ToObject<SearchTvSeason>(),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
             return result;
         }
 

--- a/TMDbLibTests/Helpers/IdHelper.cs
+++ b/TMDbLibTests/Helpers/IdHelper.cs
@@ -51,6 +51,7 @@
         public const int TomHanks = 31;
         public const string ImdbBruceWillis = "nm0000246";
         public const int JoshACagan = 129305;
+        public const int AnnaTorv = 30084;
 
         // Collections
         public const int JamesBondCollection = 645;

--- a/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
+++ b/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
@@ -57,7 +57,7 @@ namespace TMDbLibTests.UtilityTests
         /// Tests the TaggedImageConverter
         /// </summary>
         [Theory]
-        [InlineData(IdHelper.HughLaurie)]   // Has Movie media
+        [InlineData(IdHelper.HughLaurie)] // Has Movie media
         [InlineData(IdHelper.TomHanks)] // Has Episode media
         [InlineData(IdHelper.AnnaTorv)] // Has Tv, Season media
         public async Task TestJsonTaggedImageConverter(int personId)

--- a/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
+++ b/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
@@ -59,6 +59,7 @@ namespace TMDbLibTests.UtilityTests
         [Theory]
         [InlineData(IdHelper.HughLaurie)]   // Has Movie media
         [InlineData(IdHelper.TomHanks)] // Has Episode media
+        [InlineData(IdHelper.AnnaTorv)] // Has Tv, Season media
         public async Task TestJsonTaggedImageConverter(int personId)
         {
             // Get images
@@ -77,6 +78,8 @@ namespace TMDbLibTests.UtilityTests
                     Assert.IsType<SearchTv>(item.Media);
                 else if (item.MediaType == MediaType.Episode)
                     Assert.IsType<SearchTvEpisode>(item.Media);
+                else if (item.MediaType == MediaType.Season)
+                    Assert.IsType<SearchTvSeason>(item.Media);
                 else
                     Assert.False(true, $"Unexpected type {item.GetType().Name}");
             });


### PR DESCRIPTION
Fixes: #414, #415, #420, #430

This will do the trick, but it would be nicer if we could map two different enum values to the same enum.
Like this:

```
[EnumValue("episode")]
[EnumValue("tv_episode")]
Episode = 4,
```
or
```
[EnumValue("episode", "tv_episode")]
Episode = 4,
```