### PR TITLE
Add Runtime to TvEpisodeBase

### DIFF
--- a/TMDbLib/Objects/TvShows/TvEpisodeBase.cs
+++ b/TMDbLib/Objects/TvShows/TvEpisodeBase.cs
@@ -30,6 +30,6 @@ namespace TMDbLib.Objects.TvShows
         public int VoteCount { get; set; }
 
         [JsonProperty("runtime")]
-        public int Runtime { get; set; }
+        public int? Runtime { get; set; }
     }
 }

--- a/TMDbLib/Objects/TvShows/TvEpisodeBase.cs
+++ b/TMDbLib/Objects/TvShows/TvEpisodeBase.cs
@@ -28,5 +28,8 @@ namespace TMDbLib.Objects.TvShows
 
         [JsonProperty("vote_count")]
         public int VoteCount { get; set; }
+
+        [JsonProperty("runtime")]
+        public int Runtime { get; set; }
     }
 }


### PR DESCRIPTION
I was about to use the runtime for the episode and found it was missing from the library. :smiling_face_with_tear: 