### PR TITLE
Add missing Collection Translations

### DIFF
--- a/TMDbLib/Client/TMDbClientCollections.cs
+++ b/TMDbLib/Client/TMDbClientCollections.cs
@@ -74,9 +74,9 @@ namespace TMDbLib.Client
             return await GetCollectionMethodInternal<ImagesWithId>(collectionId, CollectionMethods.Images, language, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<TranslationsContainer> GetCollectionTranslationsAsync(int collecitonId, CancellationToken cancellationToken = default)
+        public async Task<TranslationsContainer> GetCollectionTranslationsAsync(int collectionId, CancellationToken cancellationToken = default)
         {
-            return await GetCollectionMethodInternal<TranslationsContainer>(collecitonId, CollectionMethods.Translations, null, cancellationToken).ConfigureAwait(false);
+            return await GetCollectionMethodInternal<TranslationsContainer>(collectionId, CollectionMethods.Translations, null, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/TMDbLib/Client/TMDbClientCollections.cs
+++ b/TMDbLib/Client/TMDbClientCollections.cs
@@ -73,5 +73,10 @@ namespace TMDbLib.Client
         {
             return await GetCollectionMethodInternal<ImagesWithId>(collectionId, CollectionMethods.Images, language, cancellationToken).ConfigureAwait(false);
         }
+
+        public async Task<TranslationsContainer> GetCollectionTranslationsAsync(int collecitonId, CancellationToken cancellationToken = default)
+        {
+            return await GetCollectionMethodInternal<TranslationsContainer>(collecitonId, CollectionMethods.Translations, null, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/TMDbLib/Objects/Collections/Collection.cs
+++ b/TMDbLib/Objects/Collections/Collection.cs
@@ -16,6 +16,9 @@ namespace TMDbLib.Objects.Collections
         [JsonProperty("images")]
         public Images Images { get; set; }
 
+        [JsonProperty("translations")]
+        public TranslationsContainer Translations { get; set; }
+
         [JsonProperty("name")]
         public string Name { get; set; }
 

--- a/TMDbLib/Objects/Collections/CollectionMethods.cs
+++ b/TMDbLib/Objects/Collections/CollectionMethods.cs
@@ -9,6 +9,8 @@ namespace TMDbLib.Objects.Collections
         [EnumValue("Undefined")]
         Undefined = 0,
         [EnumValue("images")]
-        Images = 1
+        Images = 1,
+        [EnumValue("translations")]
+        Translations = 2,
     }
 }


### PR DESCRIPTION
Found another thing missing I needed.

While I haven't actually tested if I hooked it up correctly from within the library I have tested that the api accepts the 'translations' value in the 'append_to_response' query parameter and sends the translations with the other collection info.

Example output from the api;
![image](https://github.com/revam/dotnet-tmdblib/assets/7761729/804b284b-aced-4b02-b3be-846046970b40)