### PR TITLE
Update the TargetFrameworks

### DIFF
--- a/TMDbLib/TMDbLib.csproj
+++ b/TMDbLib/TMDbLib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Authors>LordMike;Naliath</Authors>
-    <TargetFrameworks>net45;netstandard2.1;netstandard2.0;netstandard1.2</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>TMDbLib</AssemblyName>
     <PackageId>TMDbLib</PackageId>
     <Description>.NET Client library for The Movie Database (https://www.themoviedb.org/)</Description>
@@ -23,15 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="compile" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.2' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/TMDbLibTests/TMDbLibTests.csproj
+++ b/TMDbLibTests/TMDbLibTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\_Imports\Test.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +18,7 @@
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" PrivateAssets="All" />
-    <PackageReference Include="Verify.Xunit" Version="14.14.1" />
+    <PackageReference Include="Verify.Xunit" Version="17.10.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
+++ b/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
@@ -81,7 +81,7 @@ namespace TMDbLibTests.UtilityTests
                 else if (item.MediaType == MediaType.Season)
                     Assert.IsType<SearchTvSeason>(item.Media);
                 else
-                    Assert.False(true, $"Unexpected type {item.GetType().Name}");
+                    Assert.Fail($"Unexpected type {item.GetType().Name}");
             });
         }
     }

--- a/TestApplication/TestApplication.csproj
+++ b/TestApplication/TestApplication.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\_Imports\Test.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
Targeting netstandard2.0 and net6.0 should be enough for the library as that should support all currently supported verions of .Net Framework (4.6.2+) and .NET (6.0+) while allowing it to compile on linux.

(Technically .NET Framework 3.5 Service Pack 1 is still supported but we
 currently don't support that anyway)

For the test projects I just went with the latest .NET version as .NET 5.0 isn't supported anymore.