### PR TITLE
Update test projects to .NET7 and update VerifyTests

### DIFF
--- a/TMDbLibTests/TMDbLibTests.csproj
+++ b/TMDbLibTests/TMDbLibTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\_Imports\Test.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +18,7 @@
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" PrivateAssets="All" />
-    <PackageReference Include="Verify.Xunit" Version="14.14.1" />
+    <PackageReference Include="Verify.Xunit" Version="17.10.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
+++ b/TMDbLibTests/UtilityTests/TaggedImageConverterTest.cs
@@ -81,7 +81,7 @@ namespace TMDbLibTests.UtilityTests
                 else if (item.MediaType == MediaType.Season)
                     Assert.IsType<SearchTvSeason>(item.Media);
                 else
-                    Assert.False(true, $"Unexpected type {item.GetType().Name}");
+                    Assert.Fail($"Unexpected type {item.GetType().Name}");
             });
         }
     }

--- a/TestApplication/TestApplication.csproj
+++ b/TestApplication/TestApplication.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\_Imports\Test.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
17.10.2 is that last version that doesn't use a forked newtonsoft.json
Also fixes a XUnit warning