### PR TITLE
Added vote average to TvSeason

### DIFF
--- a/TMDbLib/Objects/TvShows/TvSeason.cs
+++ b/TMDbLib/Objects/TvShows/TvSeason.cs
@@ -44,6 +44,9 @@ namespace TMDbLib.Objects.TvShows
         [JsonProperty("season_number")]
         public int SeasonNumber { get; set; }
 
+        [JsonProperty("vote_average")]
+        public double VoteAverage { get; set; }
+
         [JsonProperty("videos")]
         public ResultContainer<Video> Videos { get; set; }
 


### PR DESCRIPTION
This adds the missing `vote_average` field to the `TvSeason` object. That's pretty much it!