### PR TITLE
Add Episode Type property to TV Season Episode

### DIFF
--- a/TMDbLib/Objects/Search/TvSeasonEpisode.cs
+++ b/TMDbLib/Objects/Search/TvSeasonEpisode.cs
@@ -17,6 +17,9 @@ namespace TMDbLib.Objects.Search
         [JsonProperty("episode_number")]
         public int EpisodeNumber { get; set; }
 
+        [JsonProperty("episode_type")]
+        public string EpisodeType { get; set; }
+
         [JsonProperty("guest_stars")]
         public List<Cast> GuestStars { get; set; }
 
@@ -37,7 +40,7 @@ namespace TMDbLib.Objects.Search
 
         [JsonProperty("season_number")]
         public int SeasonNumber { get; set; }
-        
+
         [JsonProperty("still_path")]
         public string StillPath { get; set; }
 


### PR DESCRIPTION
Add `episode_type` property to each _Episode_ that comes with _TV Season_ entity. That is, the `TvSeasonEpisode` class.

This entity comes using the call https://developer.themoviedb.org/reference/tv-season-details