### PR TITLE
Add missing properties to SearchCollection class

### DIFF
--- a/TMDbLib/Objects/Search/SearchCollection.cs
+++ b/TMDbLib/Objects/Search/SearchCollection.cs
@@ -4,6 +4,9 @@ namespace TMDbLib.Objects.Search
 {
     public class SearchCollection
     {
+        [JsonProperty("adult")]
+        public bool Adult { get; set; }
+        
         [JsonProperty("backdrop_path")]
         public string BackdropPath { get; set; }
 
@@ -12,6 +15,15 @@ namespace TMDbLib.Objects.Search
 
         [JsonProperty("name")]
         public string Name { get; set; }
+        
+        [JsonProperty("original_language")]
+        public string OriginalLanguage { get; set; }
+        
+        [JsonProperty("original_name")]
+        public string OriginalName { get; set; }
+        
+        [JsonProperty("overview")]
+        public string Overview { get; set; }
 
         [JsonProperty("poster_path")]
         public string PosterPath { get; set; }


### PR DESCRIPTION
New properties have been added to the SearchCollection class as per TMDB API documentation. These include properties for 'adult', 'original language', 'original name', and 'overview' which were initially missing in the class definition.