### PR TITLE
Fix #505 - Add support for media type 'Collection' in SearchMultiAsync

### DIFF
--- a/TMDbLib/Objects/General/MediaType.cs
+++ b/TMDbLib/Objects/General/MediaType.cs
@@ -28,6 +28,9 @@ namespace TMDbLib.Objects.General
         Season = 6,
 
         [EnumValue("tv_season")]
-        TvSeason = 7
+        TvSeason = 7,
+        
+        [EnumValue("collection")]
+        Collection = 8
     }
 }

--- a/TMDbLib/Objects/Search/SearchCollection.cs
+++ b/TMDbLib/Objects/Search/SearchCollection.cs
@@ -15,7 +15,6 @@ namespace TMDbLib.Objects.Search
         
         [JsonProperty("backdrop_path")]
         public string BackdropPath { get; set; }
-        
         private string _name;
         private string _originalName;
 

--- a/TMDbLib/Objects/Search/SearchCollection.cs
+++ b/TMDbLib/Objects/Search/SearchCollection.cs
@@ -1,26 +1,59 @@
+using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace TMDbLib.Objects.Search
 {
-    public class SearchCollection
+    public class SearchCollection : SearchBase
     {
+        // Property to hold additional data from the JSON
+        [JsonExtensionData]
+        private IDictionary<string, JToken> _additionalData;
+        
         [JsonProperty("adult")]
         public bool Adult { get; set; }
         
         [JsonProperty("backdrop_path")]
         public string BackdropPath { get; set; }
-
-        [JsonProperty("id")]
-        public int Id { get; set; }
+        
+        private string _name;
+        private string _originalName;
 
         [JsonProperty("name")]
-        public string Name { get; set; }
+        public string Name
+        {
+            get
+            {
+                // If _name is not set, attempt to retrieve the "title" property from additional data
+                if (_name == null && _additionalData != null && _additionalData.TryGetValue("title", out var nameToken))
+                {
+                    return nameToken.ToString();
+                }
+
+                return _name;
+            }
+            set => _name = value;
+        }
         
         [JsonProperty("original_language")]
         public string OriginalLanguage { get; set; }
-        
+
         [JsonProperty("original_name")]
-        public string OriginalName { get; set; }
+        public string OriginalName
+        {
+            get
+            {
+                // If _originalName is not set, attempt to retrieve the "original_title" property from additional data
+                if (_originalName == null && _additionalData != null &&
+                    _additionalData.TryGetValue("original_title", out var originalNameToken))
+                {
+                    return originalNameToken.ToString();
+                }
+
+                return _originalName;
+            }
+            set => _originalName = value;
+        }
         
         [JsonProperty("overview")]
         public string Overview { get; set; }

--- a/TMDbLib/Utilities/Converters/SearchBaseConverter.cs
+++ b/TMDbLib/Utilities/Converters/SearchBaseConverter.cs
@@ -37,6 +37,7 @@ namespace TMDbLib.Utilities.Converters
                     MediaType.TvEpisode => new SearchTvEpisode(),
                     MediaType.Season => new SearchTvSeason(),
                     MediaType.TvSeason => new SearchTvSeason(),
+                    MediaType.Collection => new SearchCollection(),
                     _ => throw new ArgumentOutOfRangeException(),
                 };
             }


### PR DESCRIPTION
This commit introduces the new media type 'Collection' to the MediaType enum and updates the relevant converters and data models to handle it. The SearchCollection class is enhanced to manage additional data and dynamically retrieve 'title' and 'original_title' fields from JSON if they are not directly set. This ensures better data consistency and expands the functionality to include collections as the returned result from searchMulti for collection has no name or original name property.