### PR TITLE
Added missing EpisodeType property to TvEpisodeBase

### DIFF
--- a/TMDbLib/Objects/TvShows/TvEpisodeBase.cs
+++ b/TMDbLib/Objects/TvShows/TvEpisodeBase.cs
@@ -31,5 +31,9 @@ namespace TMDbLib.Objects.TvShows
 
         [JsonProperty("runtime")]
         public int? Runtime { get; set; }
+
+        [JsonProperty("episode_type")]
+        public string EpisodeType { get; set; }
+
     }
 }


### PR DESCRIPTION
I noticed that TVShows/TVEpisodeBase.cs is missing the EpisodeType property, which is returned by TMDB. This property is already on the TMDBLib.Objects.Search.TvSeasonEpisode class, but missing from TvEpisodeBase. This will allow the property to be accessed for cases such as episode group requests, and Last/NextEpisodeToAir from TV show detail requests.