### PR TITLE
Fix MovieRole object which was missing some important properties

### DIFF
--- a/TMDbLib/Objects/People/MovieRole.cs
+++ b/TMDbLib/Objects/People/MovieRole.cs
@@ -6,20 +6,20 @@ namespace TMDbLib.Objects.People
     public class MovieRole
     {
 
-        [JsonProperty("order")]
-        public int Order { get; set; }
-
         [JsonProperty("adult")]
-        public bool Adult { get; set; }
+        public bool Adult { get; set; } = true;
 
-        [JsonProperty("character")]
-        public string Character { get; set; }
+        [JsonProperty("backdrop_path")]
+        public string BackdropPath { get; set; }
 
-        [JsonProperty("credit_id")]
-        public string CreditId { get; set; }
+        [JsonProperty("genre_ids")]
+        public int[] GenreIds { get; set; }
 
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public int Id { get; set; } = 0;
+
+        [JsonProperty("original_language")]
+        public string OriginalLanguage { get; set; }
 
         [JsonProperty("original_title")]
         public string OriginalTitle { get; set; }
@@ -27,34 +27,34 @@ namespace TMDbLib.Objects.People
         [JsonProperty("overview")]
         public string Overview { get; set; }
 
-        [JsonProperty("original_language")]
-        public string OriginalLanguage { get; set; }
+        [JsonProperty("popularity")]
+        public double Popularity { get; set; } = 0;
 
         [JsonProperty("poster_path")]
         public string PosterPath { get; set; }
 
         [JsonProperty("release_date")]
-        public DateTime? ReleaseDate { get; set; }
+        public string ReleaseDate { get; set; }
 
         [JsonProperty("title")]
         public string Title { get; set; }
 
-        [JsonProperty("backdrop_path")]
-        public string BackdropPath { get; set; }
-
-        [JsonProperty("vote_count")]
-        public int VoteCount { get; set; }
+        [JsonProperty("video")]
+        public bool Video { get; set; } = true;
 
         [JsonProperty("vote_average")]
-        public double VoteAverage { get; set; }
+        public double VoteAverage { get; set; } = 0;
 
-        [JsonProperty("popularity")]
-        public double Popularity { get; set; }
+        [JsonProperty("vote_count")]
+        public int VoteCount { get; set; } = 0;
 
-        [JsonProperty("genre_ids")]
-        public int[] GenreIds { get; set; }
+        [JsonProperty("character")]
+        public string Character { get; set; }
 
-        [JsonProperty("video")]
-        public bool Video { get; set; }
+        [JsonProperty("credit_id")]
+        public string CreditId { get; set; }
+
+        [JsonProperty("order")]
+        public int Order { get; set; } = 0;
     }
 }

--- a/TMDbLib/Objects/People/MovieRole.cs
+++ b/TMDbLib/Objects/People/MovieRole.cs
@@ -53,5 +53,8 @@ namespace TMDbLib.Objects.People
 
         [JsonProperty("genre_ids")]
         public int[] GenreIds { get; set; }
+
+        [JsonProperty("video")]
+        public bool Video { get; set; }
     }
 }

--- a/TMDbLib/Objects/People/MovieRole.cs
+++ b/TMDbLib/Objects/People/MovieRole.cs
@@ -34,7 +34,7 @@ namespace TMDbLib.Objects.People
         public string PosterPath { get; set; }
 
         [JsonProperty("release_date")]
-        public string ReleaseDate { get; set; }
+        public DateTime? ReleaseDate { get; set; }
 
         [JsonProperty("title")]
         public string Title { get; set; }

--- a/TMDbLib/Objects/People/MovieRole.cs
+++ b/TMDbLib/Objects/People/MovieRole.cs
@@ -33,7 +33,7 @@ namespace TMDbLib.Objects.People
         [JsonProperty("poster_path")]
         public string PosterPath { get; set; }
 
-        [JsonProperty("release_date")]
+        [JsonProperty("release_date", NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? ReleaseDate { get; set; }
 
         [JsonProperty("title")]

--- a/TMDbLib/Objects/People/MovieRole.cs
+++ b/TMDbLib/Objects/People/MovieRole.cs
@@ -5,6 +5,10 @@ namespace TMDbLib.Objects.People
 {
     public class MovieRole
     {
+
+        [JsonProperty("order")]
+        public int Order { get; set; }
+
         [JsonProperty("adult")]
         public bool Adult { get; set; }
 
@@ -20,6 +24,12 @@ namespace TMDbLib.Objects.People
         [JsonProperty("original_title")]
         public string OriginalTitle { get; set; }
 
+        [JsonProperty("overview")]
+        public string Overview { get; set; }
+
+        [JsonProperty("original_language")]
+        public string OriginalLanguage { get; set; }
+
         [JsonProperty("poster_path")]
         public string PosterPath { get; set; }
 
@@ -28,5 +38,20 @@ namespace TMDbLib.Objects.People
 
         [JsonProperty("title")]
         public string Title { get; set; }
+
+        [JsonProperty("backdrop_path")]
+        public string BackdropPath { get; set; }
+
+        [JsonProperty("vote_count")]
+        public int VoteCount { get; set; }
+
+        [JsonProperty("vote_average")]
+        public double VoteAverage { get; set; }
+
+        [JsonProperty("popularity")]
+        public double Popularity { get; set; }
+
+        [JsonProperty("genre_ids")]
+        public int[] GenreIds { get; set; }
     }
 }

--- a/TMDbLib/Objects/People/MovieRole.cs
+++ b/TMDbLib/Objects/People/MovieRole.cs
@@ -16,7 +16,7 @@ namespace TMDbLib.Objects.People
         public int[] GenreIds { get; set; }
 
         [JsonProperty("id")]
-        public int Id { get; set; } = 0;
+        public int Id { get; set; }
 
         [JsonProperty("original_language")]
         public string OriginalLanguage { get; set; }
@@ -28,7 +28,7 @@ namespace TMDbLib.Objects.People
         public string Overview { get; set; }
 
         [JsonProperty("popularity")]
-        public double Popularity { get; set; } = 0;
+        public double Popularity { get; set; }
 
         [JsonProperty("poster_path")]
         public string PosterPath { get; set; }
@@ -43,10 +43,10 @@ namespace TMDbLib.Objects.People
         public bool Video { get; set; } = true;
 
         [JsonProperty("vote_average")]
-        public double VoteAverage { get; set; } = 0;
+        public double VoteAverage { get; set; }
 
         [JsonProperty("vote_count")]
-        public int VoteCount { get; set; } = 0;
+        public int VoteCount { get; set; }
 
         [JsonProperty("character")]
         public string Character { get; set; }
@@ -55,6 +55,6 @@ namespace TMDbLib.Objects.People
         public string CreditId { get; set; }
 
         [JsonProperty("order")]
-        public int Order { get; set; } = 0;
+        public int Order { get; set; }
     }
 }


### PR DESCRIPTION
The `MovieRole` now corresponds to the [movie credits](https://developer.themoviedb.org/reference/person-movie-credits) object.

![image](https://github.com/user-attachments/assets/94f1a2f8-4cfc-4d31-a8f3-de58f3a04991)
