### PR TITLE
Update error message for `GeneralHttpException` to include the status code

### DIFF
--- a/TMDbLib/Objects/Exceptions/GeneralHttpException.cs
+++ b/TMDbLib/Objects/Exceptions/GeneralHttpException.cs
@@ -7,7 +7,7 @@ namespace TMDbLib.Objects.Exceptions
         public HttpStatusCode HttpStatusCode { get; }
 
         public GeneralHttpException(HttpStatusCode httpStatusCode)
-            : base("TMDb returned an unexpected HTTP error")
+            : base($"TMDb returned an unexpected HTTP error: {(int)httpStatusCode}")
         {
             HttpStatusCode = httpStatusCode;
         }


### PR DESCRIPTION
Updated the error message for the `GeneralHttpException` to include the status code, since I just observed a wild GHE thrown on a system outside my control and couldn't for the love of all computers find out which status code it had, even though I've tried to reproduce it and have since added GHE as an expected exception to handle in the retry policy in the app. Just wish I had the status code so I knew _why_ it threw on that one system outside my control, so here I am, adding it for any future devs in my previous position. Feel free to suggest another format if my suggested one is not accepted. Or just reject it outright, but if you do reject it, do please explain _why_ it's rejected.