### PR TITLE
Add Iso_3166_1 property to ImageData class

### DIFF
--- a/TMDbLib/Objects/General/ImageData.cs
+++ b/TMDbLib/Objects/General/ImageData.cs
@@ -19,6 +19,9 @@ namespace TMDbLib.Objects.General
         [JsonProperty("iso_639_1")]
         public string Iso_639_1 { get; set; }
 
+        [JsonProperty("iso_3166_1")]
+        public string Iso_3166_1 { get; set; }
+
         [JsonProperty("vote_average")]
         public double VoteAverage { get; set; }
 


### PR DESCRIPTION
Source: https://www.themoviedb.org/talk/68ef9288d3ebdaf5baf96baf

Seems like TMDB added iso_3166_1 to their image responses. Although the api docs haven't been updated yet, it's confirmed to be official by tmdb staff. This will be useful to implement regional images later in jellyfin.