### PR TITLE
Handle both ISO-8601 and "UTC"-suffixed dates on Video.PublishedAt

### DIFF
--- a/TMDbLib/Objects/General/Video.cs
+++ b/TMDbLib/Objects/General/Video.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
+using TMDbLib.Utilities.Converters;
 
 namespace TMDbLib.Objects.General;
 
@@ -48,6 +49,7 @@ public class Video
     /// Gets or sets the date the video was published.
     /// </summary>
     [JsonProperty("published_at")]
+    [JsonConverter(typeof(TmdbUtcTimeConverter))]
     public DateTime PublishedAt { get; set; }
 
     /// <summary>

--- a/TMDbLib/Utilities/Converters/TmdbUtcTimeConverter.cs
+++ b/TMDbLib/Utilities/Converters/TmdbUtcTimeConverter.cs
@@ -6,7 +6,11 @@ using Newtonsoft.Json.Converters;
 namespace TMDbLib.Utilities.Converters;
 
 /// <summary>
-/// JSON converter for UTC datetime values in TMDb's specific format.
+/// JSON converter for UTC datetime values returned by TMDb. Accepts both
+/// "yyyy-MM-dd HH:mm:ss UTC" (used intermittently on the videos and changes
+/// endpoints) and ISO-8601, since TMDb has historically alternated between
+/// the two for the same field. Always serializes in the "UTC"-suffixed form
+/// to preserve existing on-the-wire behavior.
 /// </summary>
 public class TmdbUtcTimeConverter : DateTimeConverterBase
 {
@@ -22,13 +26,30 @@ public class TmdbUtcTimeConverter : DateTimeConverterBase
     /// <returns>The parsed DateTime value.</returns>
     public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
+        // Newtonsoft's reader auto-parses ISO-8601 strings into DateTime when
+        // DateParseHandling = DateTime (the default). Accept that as-is.
+        if (reader.Value is DateTime dt)
+        {
+            return dt;
+        }
+
         var stringValue = reader.Value?.ToString();
         if (string.IsNullOrEmpty(stringValue))
         {
             return null;
         }
 
-        return DateTime.ParseExact(stringValue, Format, null);
+        const DateTimeStyles styles = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal;
+
+        // TMDb's "yyyy-MM-dd HH:mm:ss UTC" form.
+        if (DateTime.TryParseExact(stringValue, Format, CultureInfo.InvariantCulture, styles, out var exact))
+        {
+            return exact;
+        }
+
+        // Fall back to ISO-8601 / any other parseable form so the converter
+        // remains correct if TMDb reverts the format again.
+        return DateTime.Parse(stringValue, CultureInfo.InvariantCulture, styles);
     }
 
     /// <summary>

--- a/TMDbLibTests/UtilityTests/VideoPublishedAtTest.cs
+++ b/TMDbLibTests/UtilityTests/VideoPublishedAtTest.cs
@@ -1,0 +1,52 @@
+using System;
+using TMDbLib.Objects.General;
+using TMDbLib.Utilities.Serializer;
+using TMDbLibTests.JsonHelpers;
+using Xunit;
+
+namespace TMDbLibTests.UtilityTests;
+
+/// <summary>
+/// Tests deserialization of <see cref="Video.PublishedAt"/> across the two
+/// formats TMDb has historically returned for the field. See discussion in
+/// jellyfin/jellyfin#16722 (and prior #13171, #13173): TMDb intermittently
+/// switches between ISO-8601 and a "yyyy-MM-dd HH:mm:ss UTC" form for
+/// <c>published_at</c> on the videos endpoint.
+/// </summary>
+public class VideoPublishedAtTest : TestBase
+{
+    /// <summary>
+    /// ISO-8601 with milliseconds — the format used by TMDbLib's recorded
+    /// test fixtures and (historically) by the TMDb API.
+    /// </summary>
+    [Fact]
+    public void DeserializesIso8601PublishedAt()
+    {
+        var json = "{\"id\":\"abc\",\"published_at\":\"2024-02-01T15:27:17.000Z\"}";
+
+        var video = Serializer.DeserializeFromString<Video>(json);
+
+        Assert.NotNull(video);
+        Assert.Equal(new DateTime(2024, 2, 1, 15, 27, 17, DateTimeKind.Utc),
+            video!.PublishedAt.ToUniversalTime());
+    }
+
+    /// <summary>
+    /// "yyyy-MM-dd HH:mm:ss UTC" — the format the live TMDb /videos endpoint
+    /// returns today (and intermittently in the past). Without a converter on
+    /// <see cref="Video.PublishedAt"/>, Newtonsoft.Json's strict DateTime
+    /// reader rejects this form with <c>JsonReaderException: Could not convert
+    /// string to DateTime</c>.
+    /// </summary>
+    [Fact]
+    public void DeserializesUtcSuffixedPublishedAt()
+    {
+        var json = "{\"id\":\"abc\",\"published_at\":\"2024-02-01 15:27:17 UTC\"}";
+
+        var video = Serializer.DeserializeFromString<Video>(json);
+
+        Assert.NotNull(video);
+        Assert.Equal(new DateTime(2024, 2, 1, 15, 27, 17, DateTimeKind.Utc),
+            video!.PublishedAt.ToUniversalTime());
+    }
+}


### PR DESCRIPTION
## Summary

TMDb's videos endpoint intermittently returns `Video.published_at` in two
different formats — ISO-8601 (e.g. `2024-02-01T15:27:17.000Z`) and a
non-ISO `yyyy-MM-dd HH:mm:ss UTC` form. With no `[JsonConverter]` on the
property, Newtonsoft.Json's default DateTime reader rejects the latter
with `JsonReaderException: Could not convert string to DateTime`,
breaking `GetMovieVideosAsync` and the `videos` slice of
`GetMovieAsync(MovieMethods.Videos)` for any movie with at least one
video.

This has surfaced as user-visible breakage at least three times:

- jellyfin/jellyfin#16722 — open today (2026-04-28)
- jellyfin/jellyfin#13171, jellyfin/jellyfin#13173 — December 2024

Each prior incident self-resolved only because TMDb reverted the format
server-side; the parser was never made tolerant. Today's incident has
held for hours and is impacting downstream apps (e.g.
sbondCo/Watcharr#1050 within hours of #16722).

## Changes

- **`TmdbUtcTimeConverter`**: now accepts both the `"UTC"`-suffixed form
  and any `DateTime.Parse`-recognized form (covers ISO-8601 plus any
  future format TMDb settles on). Serialization is unchanged.
- **`Video.PublishedAt`**: apply `[JsonConverter(typeof(TmdbUtcTimeConverter))]`,
  which was missing.

## Tests

`TMDbLibTests/UtilityTests/VideoPublishedAtTest.cs` covers both formats —
committed as a separate "red" commit so reviewers can verify the failure
mode pre-fix. Pre-existing utility tests (49 total, including those on
`ChangeItemBase.Time` which uses the same converter) continue to pass.

## Repro of the original bug

```csharp
var client = new TMDbClient("<api_key>");
await client.GetMovieVideosAsync(59189); // any movie with at least one video
// Newtonsoft.Json.JsonReaderException: Could not convert string to DateTime:
// 2024-02-01 15:27:17 UTC. Path 'results[0].published_at'
```