### PR TITLE
fix: TMDb API always gzip-compresses responses

### DIFF
--- a/TMDbLib/Rest/RestClient.cs
+++ b/TMDbLib/Rest/RestClient.cs
@@ -29,6 +29,7 @@ internal sealed class RestClient : IDisposable
         {
             var handler = new SocketsHttpHandler
             {
+                AutomaticDecompression = DecompressionMethods.All,
                 ConnectCallback = HappyEyeballsCallback.ConnectAsync
             };
 


### PR DESCRIPTION
The TMDb API now always returns gzip-compressed responses, regardless of the Accept-Encoding header. The SocketsHttpHandler in RestClient.cs doesn't have AutomaticDecompression enabled, so the raw gzip bytes are passed to the JSON deserializer.